### PR TITLE
Error handling of MatrixConstrainedLinearRegression #5

### DIFF
--- a/constrained_linear_regression/__init__.py
+++ b/constrained_linear_regression/__init__.py
@@ -100,7 +100,7 @@ class MatrixConstrainedLinearRegression(LinearModel, RegressorMixin):
             accept_sparse=['csr', 'csc', 'coo'],
             y_numeric=True, multi_output=False
         )
-        X, y, X_offset, y_offset, X_scale = self._preprocess_data(
+        X, y, X_offset, y_offset, X_scale = _preprocess_data(
             X, y,
             fit_intercept=self.fit_intercept,
             normalize=self.normalize,


### PR DESCRIPTION
Fixes https://github.com/avidale/constrained-linear-regression/issues/4 : AttributeError: 'MatrixConstrainedLinearRegression' object has no attribute '_preprocess_data' is fixed.

initially,
```
scikit-learn==1.1.0
```
constrained-linear-regression 0.0.4 requires scikit-learn<=1.1

Run the reproducing error code at https://github.com/avidale/constrained-linear-regression/issues/4
```
X, y, X_offset, y_offset, X_scale = self._preprocess_data(
AttributeError: 'MatrixConstrainedLinearRegression' object has no attribute '_preprocess_data'
```

If I upgrade scikit-learn?
```
pip install -U scikit-learn==1.2.2
pip list | grep -E "(constrained|scikit)"
constrained-linear-regression 0.0.4
scikit-learn                  1.2.2
```
Run the reproducing error code at https://github.com/avidale/constrained-linear-regression/issues/4
```
X, y, X_offset, y_offset, X_scale = self._preprocess_data(
AttributeError: 'MatrixConstrainedLinearRegression' object has no attribute '_preprocess_data'
```